### PR TITLE
Use atomic reference counters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ impl_ops = "0.1.1"
 num-bigint = "0.2.6"
 num-integer = "0.1.42"
 num-traits = "0.2.11"
-doc-comment = "0.3.1"
+doc-comment = "0.3.3"
+atomic_refcell = "0.1.6"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/edwards/scalar.rs
+++ b/src/edwards/scalar.rs
@@ -57,7 +57,7 @@ impl Scalar {
         Scalar { k, r }
     }
     #[inline]
-    pub fn inv_mod(&self) -> Scalar {
+    fn inv_mod(&self) -> Scalar {
         let exp = &self.r - 2u32;
         self.red(self.k.modpow(&exp, &self.r))
     }

--- a/src/montgomery/scalar.rs
+++ b/src/montgomery/scalar.rs
@@ -57,7 +57,7 @@ impl Scalar {
         Scalar { k, r }
     }
     #[inline]
-    pub fn inv_mod(&self) -> Scalar {
+    fn inv_mod(&self) -> Scalar {
         let exp = &self.r - 2u32;
         self.red(self.k.modpow(&exp, &self.r))
     }

--- a/src/weierstrass/scalar.rs
+++ b/src/weierstrass/scalar.rs
@@ -57,7 +57,7 @@ impl Scalar {
         Scalar { k, r }
     }
     #[inline]
-    pub fn inv_mod(&self) -> Scalar {
+    fn inv_mod(&self) -> Scalar {
         let exp = &self.r - 2u32;
         self.red(self.k.modpow(&exp, &self.r))
     }


### PR DESCRIPTION
Any applications that need to implement the `Send` or `Sync` traits will need the underlying library to use atomic reference counters for handling internal data.