### PR TITLE
Updates interface for generating points

### DIFF
--- a/benches/field.rs
+++ b/benches/field.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Benchmark, Criterion};
 
 use redox_ecc::ellipticcurve::EllipticCurve;
-use redox_ecc::field::FromFactory;
 use redox_ecc::instances::{GetCurve, P256, P384, P521};
+use redox_ecc::ops::FromFactory;
 
 fn arith(c: &mut Criterion) {
     for id in [P256, P384, P521].iter() {

--- a/src/edwards/curve.rs
+++ b/src/edwards/curve.rs
@@ -2,17 +2,18 @@
 //!
 //! The curve module is meant to be used for bar.
 
-use num_bigint::{BigInt, BigUint, ToBigInt, Sign};
+use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
 use num_traits::identities::Zero;
 
+use std::io::{Error, ErrorKind};
 use std::str::FromStr;
-use std::io::{Error,ErrorKind};
 
 use crate::do_if_eq;
 use crate::edwards::point::{Point, ProyCoordinates};
 use crate::edwards::scalar::Scalar;
-use crate::ellipticcurve::{EllipticCurve,Decode};
-use crate::field::{Field, FromFactory, Sqrt, Sgn0};
+use crate::ellipticcurve::{Decode, EllipticCurve};
+use crate::field::{Field, Sgn0, Sqrt};
+use crate::ops::FromFactory;
 use crate::primefield::{Fp, FpElt};
 
 /// This is an elliptic curve defined in the twisted Edwards model and defined by the equation:
@@ -20,7 +21,7 @@ use crate::primefield::{Fp, FpElt};
 ///
 #[derive(Clone, PartialEq)]
 pub struct Curve {
-    pub(super) f: Fp,
+    f: Fp,
     pub(super) a: FpElt,
     pub(super) d: FpElt,
     pub(super) r: BigUint,
@@ -29,22 +30,39 @@ pub struct Curve {
     pub(super) h: BigUint,
 }
 
-impl EllipticCurve for Curve {
-    type F = Fp;
-    type Scalar = Scalar;
-    type Point = Point;
-    type Coordinates = ProyCoordinates;
-    fn new_point(&self, c: Self::Coordinates) -> Self::Point {
+impl Curve {
+    pub(crate) fn new_proy_point(&self, c: ProyCoordinates) -> Point {
         let e = self.clone();
         let pt = Point { e, c };
         do_if_eq!(self.is_on_curve(&pt), pt, ERR_ECC_NEW)
     }
+}
+
+impl EllipticCurve for Curve {
+    type F = Fp;
+    type Scalar = Scalar;
+    type Point = Point;
+    fn new_point(&self, x: <Self::F as Field>::Elt, y: <Self::F as Field>::Elt) -> Self::Point {
+        let e = self.clone();
+        let f = e.get_field();
+        let pt = Point {
+            c: ProyCoordinates {
+                t: &x * &y,
+                x,
+                y,
+                z: f.one(),
+            },
+            e,
+        };
+        do_if_eq!(self.is_on_curve(&pt), pt, ERR_ECC_NEW)
+    }
+
     fn new_scalar(&self, k: BigInt) -> Self::Scalar {
         Scalar::new(k, &self.r)
     }
     fn identity(&self) -> Self::Point {
         let f = &self.f;
-        self.new_point(ProyCoordinates {
+        self.new_proy_point(ProyCoordinates {
             x: f.zero(),
             y: f.one(),
             t: f.zero(),
@@ -71,11 +89,11 @@ impl EllipticCurve for Curve {
     fn get_cofactor(&self) -> BigInt {
         self.h.to_bigint().unwrap()
     }
-    fn get_field(&self) -> Self::F {
-        self.f.clone()
+    fn get_field(&self) -> &Self::F {
+        &self.f
     }
     fn get_generator(&self) -> Self::Point {
-        self.new_point(ProyCoordinates {
+        self.new_proy_point(ProyCoordinates {
             x: self.gx.clone(),
             y: self.gy.clone(),
             t: &self.gx * &self.gy,
@@ -87,15 +105,15 @@ impl EllipticCurve for Curve {
 impl Decode for Curve {
     type Deser = Point;
     // based on https://tools.ietf.org/html/rfc8032#section-5.2.3
-    fn decode(&self, buf: &[u8]) -> Result<Self::Deser,Error> {
+    fn decode(&self, buf: &[u8]) -> Result<Self::Deser, Error> {
         // step 1
         if buf.len() == 0 {
             return Err(Error::new(ErrorKind::Other, "Input buffer is empty."));
         }
-        let last_byte = buf.len()-1;
-        let x_0 = (buf[last_byte]>>7)&0x01;
+        let last_byte = buf.len() - 1;
+        let x_0 = (buf[last_byte] >> 7) & 0x01;
         let mut y_bytes = buf.to_vec();
-        y_bytes[last_byte] = y_bytes[last_byte]&127; // clear msb
+        y_bytes[last_byte] = y_bytes[last_byte] & 127; // clear msb
         let y_zz = BigInt::from_bytes_le(Sign::Plus, &y_bytes);
         let p = self.f.get_modulus();
         if y_zz > p {
@@ -104,28 +122,26 @@ impl Decode for Curve {
         let y = self.f.elt(y_zz);
 
         // step 2
-        let yy = &y*&y;
+        let yy = &y * &y;
         let minus_one = -self.f.one();
         let u = &yy + &minus_one;
-        let v = (&self.d * &yy)  - &self.a;
-        let u_inv_v = u/v;
+        let v = (&self.d * &yy) - &self.a;
+        let u_inv_v = u / v;
         let x_sqrt = u_inv_v.sqrt();
 
         // step 4 (step 3 is unnecessary)
         if x_sqrt == self.f.zero() && x_0 == 0x01 {
-            return Err(Error::new(ErrorKind::Other, "Failed decoding on square root"));
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Failed decoding on square root",
+            ));
         }
-        let tag = ((x_sqrt.sgn0_le()>>1)&0x01) as u8;
+        let tag = ((x_sqrt.sgn0_le() >> 1) & 0x01) as u8;
         let mut x = x_sqrt;
         if tag != x_0 {
             x = -x;
         }
-        Ok(self.new_point(ProyCoordinates {
-            x: x.clone(),
-            y: y.clone(),
-            t: &x * &y,
-            z: self.f.one()
-        }))
+        Ok(self.new_point(x, y))
     }
 }
 
@@ -171,9 +187,9 @@ const ERR_ECC_NEW: &str = "not valid point";
 // tests for ser/deser
 #[cfg(test)]
 mod tests {
-    use crate::instances::{EDWARDS25519, EDWARDS448, GetCurve};
-    use crate::ellipticcurve::{EllipticCurve, Encode, Decode};
+    use crate::ellipticcurve::{Decode, EllipticCurve, Encode};
     use crate::field::Field;
+    use crate::instances::{GetCurve, EDWARDS25519, EDWARDS448};
 
     #[test]
     fn point_serialization() {
@@ -182,13 +198,14 @@ mod tests {
             let modulus = ec.get_field().get_modulus();
             let gen = ec.get_generator();
             let ser = gen.encode(false); // compression does not exist
-            assert_eq!(ser.len(), (modulus.bits()+7)/8);
+            assert_eq!(ser.len(), (modulus.bits() + 7) / 8);
             let deser = ec.decode(&ser).unwrap();
-            assert!(ec.is_on_curve(&deser), "decompressed point validity check for {}", id);
             assert!(
-                gen == deser,
-                "decompressed point equality check for {}", id
+                ec.is_on_curve(&deser),
+                "decompressed point validity check for {}",
+                id
             );
+            assert!(gen == deser, "decompressed point equality check for {}", id);
         }
     }
 }

--- a/src/edwards/elligator2.rs
+++ b/src/edwards/elligator2.rs
@@ -41,7 +41,7 @@ impl MapToCurve for Ell2 {
     type E = TeCurve;
     fn map(
         &self,
-        u: <<Self::E as EllipticCurve>::F as Field>::Elt,
+        u: &<<Self::E as EllipticCurve>::F as Field>::Elt,
     ) -> <Self::E as EllipticCurve>::Point {
         self.ratmap.pull(self.map_to_curve.map(u))
     }

--- a/src/edwards/point.rs
+++ b/src/edwards/point.rs
@@ -8,7 +8,7 @@ use crate::do_if_eq;
 use crate::edwards::curve::Curve;
 use crate::edwards::scalar::Scalar;
 use crate::ellipticcurve::{EcPoint, EllipticCurve, Encode};
-use crate::field::Sgn0;
+use crate::field::{Field, Sgn0};
 use crate::ops::ScMulRef;
 use crate::ops::Serialize;
 use crate::primefield::FpElt;
@@ -43,6 +43,9 @@ impl Encode for Point {
         // negative == odd
         let x_0 = (((x.sgn0_le() >> 1) & 0x01) << 7) as u8;
         let mut enc = y.to_bytes_le();
+        let p = self.e.f.get_modulus();
+        let size = (p.bits() + 1 + 7) / 8;
+        enc.resize(size, 0u8);
         let last = enc.len() - 1;
         enc[last] = enc[last] | x_0;
         enc

--- a/src/edwards/point.rs
+++ b/src/edwards/point.rs
@@ -8,10 +8,10 @@ use crate::do_if_eq;
 use crate::edwards::curve::Curve;
 use crate::edwards::scalar::Scalar;
 use crate::ellipticcurve::{EcPoint, EllipticCurve, Encode};
-use crate::ops::ScMulRef;
-use crate::primefield::FpElt;
 use crate::field::Sgn0;
+use crate::ops::ScMulRef;
 use crate::ops::Serialize;
+use crate::primefield::FpElt;
 
 #[derive(Clone)]
 pub struct ProyCoordinates {
@@ -41,9 +41,9 @@ impl Encode for Point {
         let x = &coords.x;
         let y = &coords.y;
         // negative == odd
-        let x_0 = (((x.sgn0_le()>>1)&0x01)<<7) as u8;
+        let x_0 = (((x.sgn0_le() >> 1) & 0x01) << 7) as u8;
         let mut enc = y.to_bytes_le();
-        let last = enc.len()-1;
+        let last = enc.len() - 1;
         enc[last] = enc[last] | x_0;
         enc
     }
@@ -58,7 +58,7 @@ impl Point {
         self.c.z.set_one();
     }
     fn core_neg(&self) -> Point {
-        self.e.new_point(ProyCoordinates {
+        self.e.new_proy_point(ProyCoordinates {
             x: -&self.c.x,
             y: self.c.y.clone(),
             t: -&self.c.t,
@@ -81,7 +81,7 @@ impl Point {
         let y3 = &gg * &hh; // Y3 = G * H
         let t3 = ee * hh; // T3 = E * H
         let z3 = ff * gg; // Z3 = F * G
-        self.e.new_point(ProyCoordinates {
+        self.e.new_proy_point(ProyCoordinates {
             x: x3,
             y: y3,
             t: t3,
@@ -99,6 +99,8 @@ impl Point {
         q
     }
 }
+
+impl Eq for Point {}
 
 impl PartialEq for Point {
     fn eq(&self, other: &Self) -> bool {

--- a/src/ellipticcurve.rs
+++ b/src/ellipticcurve.rs
@@ -44,7 +44,7 @@ pub trait EllipticCurve: Decode {
     fn is_on_curve(&self, _: &Self::Point) -> bool;
     fn get_order(&self) -> BigUint;
     fn get_cofactor(&self) -> BigInt;
-    fn get_field(&self) -> &Self::F;
+    fn get_field(&self) -> Self::F;
 }
 
 /// Rational map between two elliptic curves.
@@ -63,6 +63,6 @@ pub trait MapToCurve {
     type E: EllipticCurve;
     fn map(
         &self,
-        _: <<Self::E as EllipticCurve>::F as Field>::Elt,
+        _: &<<Self::E as EllipticCurve>::F as Field>::Elt,
     ) -> <Self::E as EllipticCurve>::Point;
 }

--- a/src/ellipticcurve.rs
+++ b/src/ellipticcurve.rs
@@ -7,12 +7,12 @@ use num_bigint::{BigInt, BigUint};
 use std::fmt::Display;
 
 use crate::field::Field;
-use crate::ops::{AddRef, DivRef, MulRef, NegRef, ScMulRef, SubRef, Serialize};
+use crate::ops::{AddRef, DivRef, MulRef, NegRef, ScMulRef, Serialize, SubRef};
 /// EcScalar models the behaviour of a scalar to multiply points.
 pub trait EcScalar: Display + AddRef + SubRef + MulRef + DivRef + NegRef + Serialize {}
 
 /// EcPoint models the behaviour of a point on an elliptic curve.
-pub trait EcPoint<T>: Display + AddRef + SubRef + NegRef + ScMulRef<T> + Encode
+pub trait EcPoint<T>: Display + AddRef + SubRef + NegRef + ScMulRef<T> + Encode + Eq
 where
     T: EcScalar,
 {
@@ -37,15 +37,14 @@ pub trait EllipticCurve: Decode {
     type F: Field;
     type Scalar: EcScalar;
     type Point: EcPoint<Self::Scalar>;
-    type Coordinates;
     fn identity(&self) -> Self::Point;
-    fn new_point(&self, _: Self::Coordinates) -> Self::Point;
+    fn new_point(&self, x: <Self::F as Field>::Elt, y: <Self::F as Field>::Elt) -> Self::Point;
     fn new_scalar(&self, _: BigInt) -> Self::Scalar;
     fn get_generator(&self) -> Self::Point;
     fn is_on_curve(&self, _: &Self::Point) -> bool;
     fn get_order(&self) -> BigUint;
     fn get_cofactor(&self) -> BigInt;
-    fn get_field(&self) -> Self::F;
+    fn get_field(&self) -> &Self::F;
 }
 
 /// Rational map between two elliptic curves.

--- a/src/field.rs
+++ b/src/field.rs
@@ -91,4 +91,5 @@ where
     fn zero(&self) -> Self::Elt;
     fn one(&self) -> Self::Elt;
     fn get_modulus(&self) -> BigInt;
+    fn size_bytes(&self) -> usize;
 }

--- a/src/instances/rational_maps.rs
+++ b/src/instances/rational_maps.rs
@@ -2,11 +2,12 @@ use crate::edwards;
 use crate::edwards::Curve as EdCurve;
 use crate::edwards::Point as TePoint;
 use crate::ellipticcurve::{EcPoint, EllipticCurve, RationalMap};
-use crate::field::{Field, FromFactory};
+use crate::field::Field;
 use crate::instances::{GetCurve, CURVE25519, CURVE448, EDWARDS25519, EDWARDS448};
 use crate::montgomery;
 use crate::montgomery::Curve as MtCurve;
 use crate::montgomery::Point as MtPoint;
+use crate::ops::FromFactory;
 use crate::primefield::FpElt;
 
 pub fn edwards25519_to_curve25519() -> impl RationalMap<E0 = EdCurve, E1 = MtCurve> {
@@ -43,7 +44,7 @@ impl RationalMap for Ed2Mt25519 {
             let xx = x * &t0;
             let yy = &self.invsqr_d * z * t0;
             let zz = x * (z - y);
-            self.e1.new_point(montgomery::ProyCoordinates {
+            self.e1.new_proy_point(montgomery::ProyCoordinates {
                 x: xx,
                 y: yy,
                 z: zz,
@@ -55,7 +56,7 @@ impl RationalMap for Ed2Mt25519 {
             self.e0.identity()
         } else if p.is_two_torsion() {
             let ff = self.e0.get_field();
-            self.e0.new_point(edwards::ProyCoordinates {
+            self.e0.new_proy_point(edwards::ProyCoordinates {
                 x: ff.zero(),
                 y: -ff.one(),
                 t: ff.zero(),
@@ -69,7 +70,7 @@ impl RationalMap for Ed2Mt25519 {
             let yy = y * &sub;
             let tt = &self.invsqr_d * x * sub;
             let zz = y * add;
-            self.e0.new_point(edwards::ProyCoordinates {
+            self.e0.new_proy_point(edwards::ProyCoordinates {
                 x: xx,
                 y: yy,
                 t: tt,
@@ -113,7 +114,7 @@ impl RationalMap for Ed4isoMt448 {
             let zz = x * &x2; // zz = x^3
             let xx = x * &y2; // xx = x*y^2
             let yy = y * (f2 * z2 - y2 - x2); // yy = y*(2z^2-y^2-x^2)
-            self.e1.new_point(montgomery::ProyCoordinates {
+            self.e1.new_proy_point(montgomery::ProyCoordinates {
                 x: xx,
                 y: yy,
                 z: zz,
@@ -143,7 +144,7 @@ impl RationalMap for Ed4isoMt448 {
             let xx = &xx * &z1;
             let yy = &yy * &z0;
             let zz = z0 * z1;
-            self.e0.new_point(edwards::ProyCoordinates {
+            self.e0.new_proy_point(edwards::ProyCoordinates {
                 x: xx,
                 y: yy,
                 t: tt,

--- a/src/montgomery/curve.rs
+++ b/src/montgomery/curve.rs
@@ -3,26 +3,27 @@
 //! The curve module is meant to be used for bar.
 
 extern crate num_bigint;
-use num_bigint::{BigInt, BigUint, ToBigInt, Sign};
+use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
 
 use num_traits::identities::Zero;
 
+use std::io::{Error, ErrorKind};
 use std::str::FromStr;
-use std::io::{Error,ErrorKind};
 
 use crate::do_if_eq;
-use crate::ellipticcurve::{EllipticCurve, Decode};
-use crate::field::{Field, FromFactory, Sgn0, Sqrt};
-use crate::primefield::{Fp, FpElt};
+use crate::ellipticcurve::{Decode, EllipticCurve};
+use crate::field::{Field, Sgn0, Sqrt};
 use crate::montgomery::point::{Point, ProyCoordinates};
 use crate::montgomery::scalar::Scalar;
+use crate::ops::FromFactory;
+use crate::primefield::{Fp, FpElt};
 
 /// This is an elliptic curve defined in Montgomery from and defined by the equation:
 /// by^2=x^3+ax^2+x.
 ///
 #[derive(Clone, PartialEq)]
 pub struct Curve {
-    pub(super) f: Fp,
+    f: Fp,
     pub(super) a: FpElt,
     pub(super) b: FpElt,
     pub(super) s: FpElt,
@@ -32,14 +33,25 @@ pub struct Curve {
     pub(super) h: BigUint,
 }
 
+impl Curve {
+    pub(crate) fn new_proy_point(&self, c: ProyCoordinates) -> Point {
+        let e = self.clone();
+        let pt = Point { e, c };
+        do_if_eq!(self.is_on_curve(&pt), pt, ERR_ECC_NEW)
+    }
+}
+
 impl EllipticCurve for Curve {
     type F = Fp;
     type Scalar = Scalar;
     type Point = Point;
-    type Coordinates = ProyCoordinates;
-    fn new_point(&self, c: Self::Coordinates) -> Self::Point {
+    fn new_point(&self, x: <Self::F as Field>::Elt, y: <Self::F as Field>::Elt) -> Self::Point {
         let e = self.clone();
-        let pt = Point { e, c };
+        let f = e.get_field();
+        let pt = Point {
+            c: ProyCoordinates { x, y, z: f.one() },
+            e,
+        };
         do_if_eq!(self.is_on_curve(&pt), pt, ERR_ECC_NEW)
     }
     fn new_scalar(&self, k: BigInt) -> Self::Scalar {
@@ -47,7 +59,7 @@ impl EllipticCurve for Curve {
     }
     fn identity(&self) -> Self::Point {
         let f = &self.f;
-        self.new_point(ProyCoordinates {
+        self.new_proy_point(ProyCoordinates {
             x: f.zero(),
             y: f.one(),
             z: f.zero(),
@@ -66,11 +78,11 @@ impl EllipticCurve for Curve {
     fn get_cofactor(&self) -> BigInt {
         self.h.to_bigint().unwrap()
     }
-    fn get_field(&self) -> Self::F {
-        self.f.clone()
+    fn get_field(&self) -> &Self::F {
+        &self.f
     }
     fn get_generator(&self) -> Self::Point {
-        self.new_point(ProyCoordinates {
+        self.new_proy_point(ProyCoordinates {
             x: self.gx.clone(),
             y: self.gy.clone(),
             z: self.f.one(),
@@ -79,16 +91,16 @@ impl EllipticCurve for Curve {
 }
 
 impl Decode for Curve {
-    type Deser = Point;
-    fn decode(&self, buf: &[u8]) -> Result<Self::Deser,std::io::Error> {
+    type Deser = <Curve as EllipticCurve>::Point;
+    fn decode(&self, buf: &[u8]) -> Result<Self::Deser, std::io::Error> {
         let p = self.f.get_modulus();
-        let max_bytes = (p.bits()+7)/8;
+        let max_bytes = (p.bits() + 7) / 8;
         if buf.len() == 0 {
             return Err(Error::new(ErrorKind::Other, "Input buffer is empty."));
         }
         let tag = buf[0];
         // check x coordinate is in the valid range, Sign::Plus => > 0
-        let x_val = BigInt::from_bytes_be(Sign::Plus, &buf[1..max_bytes+1]);
+        let x_val = BigInt::from_bytes_be(Sign::Plus, &buf[1..max_bytes + 1]);
         if x_val >= p {
             return Err(Error::new(ErrorKind::Other, "Invalid x coordinate"));
         }
@@ -96,29 +108,34 @@ impl Decode for Curve {
             0x00 => {
                 // return point of infinity
                 if buf.len() != 1 {
-                    return Err(Error::new(ErrorKind::Other, "Point at infinity should just be a single zero byte"));
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        "Point at infinity should just be a single zero byte",
+                    ));
                 }
                 Ok(self.identity())
-            },
+            }
             0x04 => {
-                if buf.len() != 2*max_bytes+1 {
-                    return Err(Error::new(ErrorKind::Other, "Invalid bytes for deserialization"));
+                if buf.len() != 2 * max_bytes + 1 {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        "Invalid bytes for deserialization",
+                    ));
                 }
                 let x = self.f.elt(x_val);
-                let y_val = BigInt::from_bytes_be(Sign::Plus, &buf[max_bytes+1..]);
+                let y_val = BigInt::from_bytes_be(Sign::Plus, &buf[max_bytes + 1..]);
                 if y_val >= p {
                     return Err(Error::new(ErrorKind::Other, "Invalid y coordinate"));
                 }
                 let y = self.f.elt(y_val);
-                Ok(self.new_point(ProyCoordinates {
-                    x: x,
-                    y: y,
-                    z: self.f.one()
-                }))
+                Ok(self.new_point(x, y))
             }
             0x02 | 0x03 => {
-                if buf.len() != max_bytes+1 {
-                    return Err(Error::new(ErrorKind::Other, "Invalid bytes for deserialization"));
+                if buf.len() != max_bytes + 1 {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        "Invalid bytes for deserialization",
+                    ));
                 }
                 // recompute y coordinate
                 let one = self.f.one();
@@ -127,22 +144,18 @@ impl Decode for Curve {
                 let xx_ax = &x_a * &x;
                 let xx_ax_1 = &xx_ax + &one;
                 let byy = &xx_ax_1 * &x;
-                let b_inv = &one/&self.b;
+                let b_inv = &one / &self.b;
                 let yy = &byy * b_inv;
                 let y_sqrt = yy.sqrt();
                 let s = y_sqrt.sgn0_le();
-                let deser_tag = (((s>>1)&0x1)+2) as u8;
+                let deser_tag = (((s >> 1) & 0x1) + 2) as u8;
                 let mut y = y_sqrt;
                 if tag != deser_tag {
                     y = -y;
                 }
-                Ok(self.new_point(ProyCoordinates {
-                    x: x,
-                    y: y,
-                    z: self.f.one()
-                }))
+                Ok(self.new_point(x, y))
             }
-            _ => Err(Error::new(ErrorKind::Other, "Invalid tag specified"))
+            _ => Err(Error::new(ErrorKind::Other, "Invalid tag specified")),
         }
     }
 }
@@ -191,41 +204,43 @@ const ERR_ECC_NEW: &str = "not valid point";
 // tests for ser/deser
 #[cfg(test)]
 mod tests {
-    use crate::instances::{CURVE25519,CURVE448,GetCurve};
-    use crate::ellipticcurve::{EllipticCurve, Encode, Decode};
+    use crate::ellipticcurve::{Decode, EllipticCurve, Encode};
     use crate::field::Field;
+    use crate::instances::{GetCurve, CURVE25519, CURVE448};
 
     #[test]
     fn point_serialization() {
-        for &id in [CURVE25519,CURVE448].iter() {
+        for &id in [CURVE25519, CURVE448].iter() {
             let ec = id.get();
             let modulus = ec.get_field().get_modulus();
             let gen = ec.get_generator();
             let ser = gen.encode(false);
-            assert_eq!(ser.len(), 2*((modulus.bits()+7)/8)+1);
+            assert_eq!(ser.len(), 2 * ((modulus.bits() + 7) / 8) + 1);
             let deser = ec.decode(&ser).unwrap();
-            assert!(ec.is_on_curve(&deser), "decompressed point validity check for {}", id);
             assert!(
-                gen == deser,
-                "decompressed point equality check for {}", id
+                ec.is_on_curve(&deser),
+                "decompressed point validity check for {}",
+                id
             );
+            assert!(gen == deser, "decompressed point equality check for {}", id);
         }
     }
 
     #[test]
     fn point_serialization_compressed() {
-        for &id in [CURVE25519,CURVE448].iter() {
+        for &id in [CURVE25519, CURVE448].iter() {
             let ec = id.get();
             let modulus = ec.get_field().get_modulus();
             let gen = ec.get_generator();
             let ser = gen.encode(true);
-            assert_eq!(ser.len(), ((modulus.bits()+7)/8)+1);
+            assert_eq!(ser.len(), ((modulus.bits() + 7) / 8) + 1);
             let deser = ec.decode(&ser).unwrap();
-            assert!(ec.is_on_curve(&deser), "compressed point validity check for {}", id);
             assert!(
-                gen == deser,
-                "compressed point equality check for {}", id
+                ec.is_on_curve(&deser),
+                "compressed point validity check for {}",
+                id
             );
+            assert!(gen == deser, "compressed point equality check for {}", id);
         }
     }
 }

--- a/src/montgomery/curve.rs
+++ b/src/montgomery/curve.rs
@@ -78,8 +78,8 @@ impl EllipticCurve for Curve {
     fn get_cofactor(&self) -> BigInt {
         self.h.to_bigint().unwrap()
     }
-    fn get_field(&self) -> &Self::F {
-        &self.f
+    fn get_field(&self) -> Self::F {
+        self.f.clone()
     }
     fn get_generator(&self) -> Self::Point {
         self.new_proy_point(ProyCoordinates {
@@ -93,14 +93,15 @@ impl EllipticCurve for Curve {
 impl Decode for Curve {
     type Deser = <Curve as EllipticCurve>::Point;
     fn decode(&self, buf: &[u8]) -> Result<Self::Deser, std::io::Error> {
-        let p = self.f.get_modulus();
-        let max_bytes = (p.bits() + 7) / 8;
-        if buf.len() == 0 {
-            return Err(Error::new(ErrorKind::Other, "Input buffer is empty."));
+        let size = self.f.size_bytes();
+        let blen = buf.len();
+        if !(blen == 1 || blen == (size + 1) || blen == (2 * size + 1)) {
+            return Err(Error::new(ErrorKind::Other, "Wrong input buffer size."));
         }
         let tag = buf[0];
         // check x coordinate is in the valid range, Sign::Plus => > 0
-        let x_val = BigInt::from_bytes_be(Sign::Plus, &buf[1..max_bytes + 1]);
+        let x_val = BigInt::from_bytes_be(Sign::Plus, &buf[1..size + 1]);
+        let p = self.f.get_modulus();
         if x_val >= p {
             return Err(Error::new(ErrorKind::Other, "Invalid x coordinate"));
         }
@@ -116,14 +117,14 @@ impl Decode for Curve {
                 Ok(self.identity())
             }
             0x04 => {
-                if buf.len() != 2 * max_bytes + 1 {
+                if buf.len() != 2 * size + 1 {
                     return Err(Error::new(
                         ErrorKind::Other,
                         "Invalid bytes for deserialization",
                     ));
                 }
                 let x = self.f.elt(x_val);
-                let y_val = BigInt::from_bytes_be(Sign::Plus, &buf[max_bytes + 1..]);
+                let y_val = BigInt::from_bytes_be(Sign::Plus, &buf[size + 1..]);
                 if y_val >= p {
                     return Err(Error::new(ErrorKind::Other, "Invalid y coordinate"));
                 }
@@ -131,7 +132,7 @@ impl Decode for Curve {
                 Ok(self.new_point(x, y))
             }
             0x02 | 0x03 => {
-                if buf.len() != max_bytes + 1 {
+                if buf.len() != size + 1 {
                     return Err(Error::new(
                         ErrorKind::Other,
                         "Invalid bytes for deserialization",
@@ -212,10 +213,10 @@ mod tests {
     fn point_serialization() {
         for &id in [CURVE25519, CURVE448].iter() {
             let ec = id.get();
-            let modulus = ec.get_field().get_modulus();
+            let len_p = ec.get_field().size_bytes();
             let gen = ec.get_generator();
             let ser = gen.encode(false);
-            assert_eq!(ser.len(), 2 * ((modulus.bits() + 7) / 8) + 1);
+            assert_eq!(ser.len(), 2 * len_p + 1);
             let deser = ec.decode(&ser).unwrap();
             assert!(
                 ec.is_on_curve(&deser),
@@ -230,10 +231,10 @@ mod tests {
     fn point_serialization_compressed() {
         for &id in [CURVE25519, CURVE448].iter() {
             let ec = id.get();
-            let modulus = ec.get_field().get_modulus();
+            let len_p = ec.get_field().size_bytes();
             let gen = ec.get_generator();
             let ser = gen.encode(true);
-            assert_eq!(ser.len(), ((modulus.bits() + 7) / 8) + 1);
+            assert_eq!(ser.len(), len_p + 1);
             let deser = ec.decode(&ser).unwrap();
             assert!(
                 ec.is_on_curve(&deser),

--- a/src/montgomery/elligator2.rs
+++ b/src/montgomery/elligator2.rs
@@ -36,12 +36,12 @@ impl MapToCurve for Ell2 {
     type E = Curve;
     fn map(
         &self,
-        u: <<Self::E as EllipticCurve>::F as Field>::Elt,
+        u: &<<Self::E as EllipticCurve>::F as Field>::Elt,
     ) -> <Self::E as EllipticCurve>::Point {
         let f = self.e.get_field();
         let cmov = FpElt::cmov;
         let sgn0 = Sgn0::new(self.sgn0);
-        let mut t1 = &u ^ 2u32; //         1.   t1 = u^2
+        let mut t1 = u ^ 2u32; //          1.   t1 = u^2
         t1 = &self.z * t1; //              2.   t1 = Z * t1              // Z * u^2
         let e1 = t1 == f.from(-1); //      3.   e1 = t1 == -1            // exceptional case: Z * u^2 == -1
         t1 = cmov(&t1, &f.zero(), e1); //  4.   t1 = CMOV(t1, 0, e1)     // if t1 == -1, set t1 = 0
@@ -58,7 +58,7 @@ impl MapToCurve for Ell2 {
         let mut x = cmov(&x2, &x1, e2); // 15.   x = CMOV(x2, x1, e2)    // If is_square(gx1), x = x1, else x = x2
         let y2 = cmov(&gx2, &gx1, e2); //  16.  y2 = CMOV(gx2, gx1, e2)  // If is_square(gx1), y2 = gx1, else y2 = gx2
         let mut y = y2.sqrt(); //          17.   y = sqrt(y2)
-        let e3 = sgn0(&u) == sgn0(&y); //  18.  e3 = sgn0(u) == sgn0(y)  // Fix sign of y
+        let e3 = sgn0(u) == sgn0(&y); //   18.  e3 = sgn0(u) == sgn0(y)  // Fix sign of y
         y = cmov(&(-&y), &y, e3); //       19.   y = CMOV(-y, y, e3)
         x = x * &self.e.b;
         y = y * &self.e.b;

--- a/src/montgomery/elligator2.rs
+++ b/src/montgomery/elligator2.rs
@@ -1,8 +1,9 @@
 use num_traits::identities::Zero;
 
 use crate::ellipticcurve::{EllipticCurve, MapToCurve};
-use crate::field::{CMov, Field, FromFactory, Sgn0, Sgn0Endianness, Sqrt};
-use crate::montgomery::{Curve, ProyCoordinates};
+use crate::field::{CMov, Field, Sgn0, Sgn0Endianness, Sqrt};
+use crate::montgomery::Curve;
+use crate::ops::FromFactory;
 use crate::primefield::FpElt;
 
 pub struct Ell2 {
@@ -37,7 +38,7 @@ impl MapToCurve for Ell2 {
         &self,
         u: <<Self::E as EllipticCurve>::F as Field>::Elt,
     ) -> <Self::E as EllipticCurve>::Point {
-        let f = &self.e.f;
+        let f = self.e.get_field();
         let cmov = FpElt::cmov;
         let sgn0 = Sgn0::new(self.sgn0);
         let mut t1 = &u ^ 2u32; //         1.   t1 = u^2
@@ -61,6 +62,6 @@ impl MapToCurve for Ell2 {
         y = cmov(&(-&y), &y, e3); //       19.   y = CMOV(-y, y, e3)
         x = x * &self.e.b;
         y = y * &self.e.b;
-        self.e.new_point(ProyCoordinates { x, y, z: f.one() })
+        self.e.new_point(x, y)
     }
 }

--- a/src/montgomery/point.rs
+++ b/src/montgomery/point.rs
@@ -6,12 +6,12 @@ use std::ops;
 
 use crate::do_if_eq;
 use crate::ellipticcurve::{EcPoint, EllipticCurve, Encode};
+use crate::field::Sgn0;
 use crate::montgomery::curve::Curve;
 use crate::montgomery::scalar::Scalar;
 use crate::ops::ScMulRef;
-use crate::primefield::FpElt;
-use crate::field::Sgn0;
 use crate::ops::Serialize;
+use crate::primefield::FpElt;
 
 #[derive(Clone)]
 pub struct ProyCoordinates {
@@ -51,11 +51,11 @@ impl Encode for Point {
             true => {
                 let s = y.sgn0_le();
                 // if sign == 1: tag = 0x02; elif sign == -1: tag = 0x03
-                let tag = (((s>>1)&0x1)+2) as u8;
+                let tag = (((s >> 1) & 0x1) + 2) as u8;
                 let mut o = vec![tag];
                 o.append(&mut x_bytes);
                 o
-            },
+            }
             _ => {
                 let mut o: Vec<u8> = vec![0x04];
                 o.append(&mut x_bytes);
@@ -74,7 +74,7 @@ impl Point {
         self.c.z.set_one();
     }
     fn core_neg(&self) -> Point {
-        self.e.new_point(ProyCoordinates {
+        self.e.new_proy_point(ProyCoordinates {
             x: self.c.x.clone(),
             y: -&self.c.y,
             z: self.c.z.clone(),
@@ -99,7 +99,7 @@ impl Point {
         let x3 = &rr * &ss - &tt * &uu;
         let y3 = tt * &ww - &vv * &ss;
         let z3 = vv * uu - rr * ww;
-        self.e.new_point(ProyCoordinates {
+        self.e.new_proy_point(ProyCoordinates {
             x: x3,
             y: y3,
             z: z3,
@@ -119,6 +119,8 @@ impl Point {
         self.c.y.is_zero() && self.c.z.is_one()
     }
 }
+
+impl Eq for Point {}
 
 impl PartialEq for Point {
     fn eq(&self, other: &Self) -> bool {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -78,3 +78,21 @@ pub trait Deserialize {
     fn from_bytes_be(&self, _: &[u8]) -> Result<Self::Deser, std::io::Error>;
     fn from_bytes_le(&self, _: &[u8]) -> Result<Self::Deser, std::io::Error>;
 }
+
+pub trait IntoFactory<T, Out>: Sized {
+    fn lift(self, _: &T) -> Out;
+}
+
+impl<T, U, O> IntoFactory<U, O> for T
+where
+    U: FromFactory<T, Output = O>,
+{
+    fn lift(self, f: &U) -> O {
+        FromFactory::from(f, self)
+    }
+}
+
+pub trait FromFactory<T: Sized> {
+    type Output;
+    fn from(&self, _: T) -> Self::Output;
+}

--- a/src/primefield/mod.rs
+++ b/src/primefield/mod.rs
@@ -74,6 +74,9 @@ impl Field for Fp {
     fn get_modulus(&self) -> BigInt {
         self.0.p.clone()
     }
+    fn size_bytes(&self) -> usize {
+        (self.0.p.bits() + 7) / 8
+    }
 }
 
 macro_rules! impl_from_factory {

--- a/src/primefield/mod.rs
+++ b/src/primefield/mod.rs
@@ -102,7 +102,7 @@ impl FromFactory<&str> for Fp {
             return self.zero();
         }
         let mut neg = 1;
-        if &sl[0..1] == "-" {
+        if sl.starts_with("-") {
             sl = &sl[1..];
             neg = -1;
         }

--- a/src/weierstrass/curve.rs
+++ b/src/weierstrass/curve.rs
@@ -3,16 +3,17 @@
 //! The curve module is meant to be used for bar.
 
 extern crate num_bigint;
-use num_bigint::{BigInt, BigUint, ToBigInt, Sign};
+use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
 
 use num_traits::identities::Zero;
 
+use std::io::{Error, ErrorKind};
 use std::str::FromStr;
-use std::io::{Error,ErrorKind};
 
 use crate::do_if_eq;
-use crate::ellipticcurve::{EllipticCurve, Decode};
-use crate::field::{Field, FromFactory, Sgn0, Sqrt};
+use crate::ellipticcurve::{Decode, EllipticCurve};
+use crate::field::{Field, Sgn0, Sqrt};
+use crate::ops::FromFactory;
 use crate::primefield::{Fp, FpElt};
 use crate::weierstrass::point::{Point, ProyCoordinates};
 use crate::weierstrass::scalar::Scalar;
@@ -22,7 +23,7 @@ use crate::weierstrass::scalar::Scalar;
 /// **Atention** This implementation only supports curves of prime order.
 #[derive(Clone, std::cmp::PartialEq)]
 pub struct Curve {
-    pub(super) f: Fp,
+    f: Fp,
     pub(super) a: FpElt,
     pub(super) b: FpElt,
     pub(super) r: BigUint,
@@ -30,22 +31,32 @@ pub struct Curve {
     pub(super) gy: FpElt,
     pub(super) h: BigUint,
 }
+impl Curve {
+    pub(crate) fn new_proy_point(&self, c: ProyCoordinates) -> Point {
+        let e = self.clone();
+        let pt = Point { e, c };
+        do_if_eq!(self.is_on_curve(&pt), pt, ERR_ECC_NEW)
+    }
+}
 
 impl EllipticCurve for Curve {
     type F = Fp;
     type Scalar = Scalar;
     type Point = Point;
-    type Coordinates = ProyCoordinates;
-    fn new_point(&self, c: Self::Coordinates) -> Self::Point {
+    fn new_point(&self, x: <Self::F as Field>::Elt, y: <Self::F as Field>::Elt) -> Self::Point {
         let e = self.clone();
-        let pt = Point { e, c };
+        let f = e.get_field();
+        let pt = Point {
+            c: ProyCoordinates { x, y, z: f.one() },
+            e,
+        };
         do_if_eq!(self.is_on_curve(&pt), pt, ERR_ECC_NEW)
     }
     fn new_scalar(&self, k: BigInt) -> Self::Scalar {
         Scalar::new(k, &self.r)
     }
     fn identity(&self) -> Self::Point {
-        self.new_point(ProyCoordinates {
+        self.new_proy_point(ProyCoordinates {
             x: self.f.zero(),
             y: self.f.one(),
             z: self.f.zero(),
@@ -64,14 +75,14 @@ impl EllipticCurve for Curve {
     fn get_order(&self) -> BigUint {
         self.r.clone()
     }
-    fn get_field(&self) -> Self::F {
-        self.f.clone()
+    fn get_field(&self) -> &Self::F {
+        &self.f
     }
     fn get_cofactor(&self) -> BigInt {
         self.h.to_bigint().unwrap()
     }
     fn get_generator(&self) -> Self::Point {
-        self.new_point(ProyCoordinates {
+        self.new_proy_point(ProyCoordinates {
             x: self.gx.clone(),
             y: self.gy.clone(),
             z: self.f.one(),
@@ -81,15 +92,15 @@ impl EllipticCurve for Curve {
 
 impl Decode for Curve {
     type Deser = Point;
-    fn decode(&self, buf: &[u8]) -> Result<Self::Deser,Error> {
+    fn decode(&self, buf: &[u8]) -> Result<Self::Deser, Error> {
         let p = self.f.get_modulus();
-        let max_bytes = (p.bits()+7)/8;
+        let max_bytes = (p.bits() + 7) / 8;
         if buf.len() == 0 {
             return Err(Error::new(ErrorKind::Other, "Input buffer is empty."));
         }
         let tag = buf[0];
         // check x coordinate is in the valid range, Sign::Plus => > 0
-        let x_val = BigInt::from_bytes_be(Sign::Plus, &buf[1..max_bytes+1]);
+        let x_val = BigInt::from_bytes_be(Sign::Plus, &buf[1..max_bytes + 1]);
         if x_val >= p {
             return Err(Error::new(ErrorKind::Other, "Invalid x coordinate"));
         }
@@ -97,29 +108,34 @@ impl Decode for Curve {
             0x00 => {
                 // return point of infinity
                 if buf.len() != 1 {
-                    return Err(Error::new(ErrorKind::Other, "Point at infinity should just be a single zero byte"));
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        "Point at infinity should just be a single zero byte",
+                    ));
                 }
                 Ok(self.identity())
-            },
+            }
             0x04 => {
-                if buf.len() != 2*max_bytes+1 {
-                    return Err(Error::new(ErrorKind::Other, "Invalid bytes for deserialization"));
+                if buf.len() != 2 * max_bytes + 1 {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        "Invalid bytes for deserialization",
+                    ));
                 }
                 let x = self.f.elt(x_val);
-                let y_val = BigInt::from_bytes_be(Sign::Plus, &buf[max_bytes+1..]);
+                let y_val = BigInt::from_bytes_be(Sign::Plus, &buf[max_bytes + 1..]);
                 if y_val >= p {
                     return Err(Error::new(ErrorKind::Other, "Invalid y coordinate"));
                 }
                 let y = self.f.elt(y_val);
-                Ok(self.new_point(ProyCoordinates {
-                    x: x,
-                    y: y,
-                    z: self.f.one()
-                }))
+                Ok(self.new_point(x, y))
             }
             0x02 | 0x03 => {
-                if buf.len() != max_bytes+1 {
-                    return Err(Error::new(ErrorKind::Other, "Invalid bytes for deserialization"));
+                if buf.len() != max_bytes + 1 {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        "Invalid bytes for deserialization",
+                    ));
                 }
                 // recompute y coordinate
                 let x = self.f.elt(x_val);
@@ -129,18 +145,14 @@ impl Decode for Curve {
                 let xxx_ax_b = &xxx_ax + &self.b;
                 let y_sqrt = xxx_ax_b.sqrt();
                 let s = y_sqrt.sgn0_le();
-                let deser_tag = (((s>>1)&0x1)+2) as u8;
+                let deser_tag = (((s >> 1) & 0x1) + 2) as u8;
                 let mut y = y_sqrt;
                 if tag != deser_tag {
                     y = -y;
                 }
-                Ok(self.new_point(ProyCoordinates {
-                    x: x,
-                    y: y,
-                    z: self.f.one()
-                }))
+                Ok(self.new_point(x, y))
             }
-            _ => Err(Error::new(ErrorKind::Other, "Invalid tag specified"))
+            _ => Err(Error::new(ErrorKind::Other, "Invalid tag specified")),
         }
     }
 }
@@ -187,41 +199,43 @@ const ERR_ECC_NEW: &str = "not valid point";
 // tests for ser/deser
 #[cfg(test)]
 mod tests {
-    use crate::instances::{P256, P384, P521, GetCurve};
-    use crate::ellipticcurve::{EllipticCurve, Encode, Decode};
+    use crate::ellipticcurve::{Decode, EllipticCurve, Encode};
     use crate::field::Field;
+    use crate::instances::{GetCurve, P256, P384, P521};
 
     #[test]
     fn point_serialization() {
-        for &id in [P256,P384,P521].iter() {
+        for &id in [P256, P384, P521].iter() {
             let ec = id.get();
             let modulus = ec.get_field().get_modulus();
             let gen = ec.get_generator();
             let ser = gen.encode(false);
-            assert_eq!(ser.len(), 2*((modulus.bits()+7)/8)+1);
+            assert_eq!(ser.len(), 2 * ((modulus.bits() + 7) / 8) + 1);
             let deser = ec.decode(&ser).unwrap();
-            assert!(ec.is_on_curve(&deser), "decompressed point validity check for {}", id);
             assert!(
-                gen == deser,
-                "decompressed point equality check for {}", id
+                ec.is_on_curve(&deser),
+                "decompressed point validity check for {}",
+                id
             );
+            assert!(gen == deser, "decompressed point equality check for {}", id);
         }
     }
 
     #[test]
     fn point_serialization_compressed() {
-        for &id in [P256,P384,P521].iter() {
+        for &id in [P256, P384, P521].iter() {
             let ec = id.get();
             let modulus = ec.get_field().get_modulus();
             let gen = ec.get_generator();
             let ser = gen.encode(true);
-            assert_eq!(ser.len(), ((modulus.bits()+7)/8)+1);
+            assert_eq!(ser.len(), ((modulus.bits() + 7) / 8) + 1);
             let deser = ec.decode(&ser).unwrap();
-            assert!(ec.is_on_curve(&deser), "compressed point validity check for {}", id);
             assert!(
-                gen == deser,
-                "compressed point equality check for {}", id
+                ec.is_on_curve(&deser),
+                "compressed point validity check for {}",
+                id
             );
+            assert!(gen == deser, "compressed point equality check for {}", id);
         }
     }
 }

--- a/src/weierstrass/point.rs
+++ b/src/weierstrass/point.rs
@@ -27,7 +27,7 @@ pub struct ProyCoordinates {
 #[derive(Clone)]
 pub struct Point {
     pub(super) e: Curve,
-    pub(super) c: ProyCoordinates,
+    pub(crate) c: ProyCoordinates,
 }
 
 impl ScMulRef<Scalar> for Point {}

--- a/src/weierstrass/point.rs
+++ b/src/weierstrass/point.rs
@@ -10,12 +10,12 @@ use std::ops;
 
 use crate::do_if_eq;
 use crate::ellipticcurve::{EcPoint, EllipticCurve, Encode};
-use crate::ops::ScMulRef;
-use crate::primefield::FpElt;
 use crate::field::Sgn0;
+use crate::ops::ScMulRef;
+use crate::ops::Serialize;
+use crate::primefield::FpElt;
 use crate::weierstrass::curve::Curve;
 use crate::weierstrass::scalar::Scalar;
-use crate::ops::Serialize;
 
 #[derive(Clone)]
 pub struct ProyCoordinates {
@@ -56,11 +56,11 @@ impl Encode for Point {
             true => {
                 let s = y.sgn0_le();
                 // if sign == 1: tag = 0x02; elif sign == -1: tag = 0x03
-                let tag = (((s>>1)&0x1)+2) as u8;
+                let tag = (((s >> 1) & 0x1) + 2) as u8;
                 let mut o = vec![tag];
                 o.append(&mut x_bytes);
                 o
-            },
+            }
             _ => {
                 let mut o: Vec<u8> = vec![0x04];
                 o.append(&mut x_bytes);
@@ -79,7 +79,7 @@ impl Point {
         self.c.z.set_one();
     }
     fn core_neg(&self) -> <Curve as EllipticCurve>::Point {
-        self.e.new_point(ProyCoordinates {
+        self.e.new_proy_point(ProyCoordinates {
             x: self.c.x.clone(),
             y: -&self.c.y,
             z: self.c.z.clone(),
@@ -136,7 +136,7 @@ impl Point {
         t0 = t3 * t1; //   38. t0 = t3 * t1
         z3 = t5 * z3; //   39. Z3 = t5 * Z3
         z3 = z3 + t0; //   40. Z3 = Z3 + t0
-        self.e.new_point(ProyCoordinates {
+        self.e.new_proy_point(ProyCoordinates {
             x: x3,
             y: y3,
             z: z3,
@@ -155,6 +155,8 @@ impl Point {
         q
     }
 }
+
+impl Eq for Point {}
 
 impl PartialEq for Point {
     fn eq(&self, other: &Self) -> bool {

--- a/src/weierstrass/sswu.rs
+++ b/src/weierstrass/sswu.rs
@@ -41,12 +41,12 @@ impl MapToCurve for SSWU {
     type E = Curve;
     fn map(
         &self,
-        u: <<Self::E as EllipticCurve>::F as Field>::Elt,
+        u: &<<Self::E as EllipticCurve>::F as Field>::Elt,
     ) -> <Self::E as EllipticCurve>::Point {
         let f = self.e.get_field();
         let cmov = FpElt::cmov;
         let sgn0 = Sgn0::new(self.sgn0);
-        let mut t1 = &u ^ 2u32; //        0.   t1 = u^2
+        let mut t1 = u ^ 2u32; //         0.   t1 = u^2
         t1 = &self.z * &t1; //            1.   t1 = Z * u^2
         let mut t2 = &t1 ^ 2u32; //       2.   t2 = t1^2
         let mut x1 = &t1 + &t2; //        3.   x1 = t1 + t2
@@ -66,7 +66,7 @@ impl MapToCurve for SSWU {
         let x = cmov(&x2, &x1, e2); //    17.   x = CMOV(x2, x1, e2)
         let y2 = cmov(&gx2, &gx1, e2); // 18.  y2 = CMOV(gx2, gx1, e2)
         let mut y = y2.sqrt(); //         19.   y = sqrt(y2)
-        let e3 = sgn0(&u) == sgn0(&y); // 20.  e3 = sgn0(u) == sgn0(y)
+        let e3 = sgn0(u) == sgn0(&y); //  20.  e3 = sgn0(u) == sgn0(y)
         y = cmov(&(-&y), &y, e3); //      21.   y = CMOV(-y, y, e3)
         self.e.new_point(x, y)
     }

--- a/src/weierstrass/sswu.rs
+++ b/src/weierstrass/sswu.rs
@@ -1,9 +1,10 @@
 use num_traits::identities::Zero;
 
 use crate::ellipticcurve::{EllipticCurve, MapToCurve};
-use crate::field::{CMov, Field, FromFactory, Sgn0, Sgn0Endianness, Sqrt};
+use crate::field::{CMov, Field, Sgn0, Sgn0Endianness, Sqrt};
+use crate::ops::FromFactory;
 use crate::primefield::FpElt;
-use crate::weierstrass::{Curve, ProyCoordinates};
+use crate::weierstrass::Curve;
 
 #[derive(Clone)]
 pub struct SSWU {
@@ -28,7 +29,7 @@ impl SSWU {
         let precond1 = !e.a.is_zero(); //              A != 0
         let precond2 = !e.b.is_zero(); //              B != 0
         let cond1 = !z.is_square(); //                 Z is non-square
-        let cond2 = *z != e.f.from(-1); //               Z != -1
+        let cond2 = *z != e.get_field().from(-1); //               Z != -1
         let x = &e.b * &(1u32 / &(z * &e.a)); //       B/(Z*A)
         let gx = &x * &((&x ^ 2u32) + &e.a) + &e.b; // g(B/(Z*A))
         let cond4 = gx.is_square(); //                 g(B/(Z*A)) is square
@@ -42,7 +43,7 @@ impl MapToCurve for SSWU {
         &self,
         u: <<Self::E as EllipticCurve>::F as Field>::Elt,
     ) -> <Self::E as EllipticCurve>::Point {
-        let f = &self.e.f;
+        let f = self.e.get_field();
         let cmov = FpElt::cmov;
         let sgn0 = Sgn0::new(self.sgn0);
         let mut t1 = &u ^ 2u32; //        0.   t1 = u^2
@@ -67,6 +68,6 @@ impl MapToCurve for SSWU {
         let mut y = y2.sqrt(); //         19.   y = sqrt(y2)
         let e3 = sgn0(&u) == sgn0(&y); // 20.  e3 = sgn0(u) == sgn0(y)
         y = cmov(&(-&y), &y, e3); //      21.   y = CMOV(-y, y, e3)
-        self.e.new_point(ProyCoordinates { x, y, z: f.one() })
+        self.e.new_point(x, y)
     }
 }

--- a/src/weierstrass/svdw.rs
+++ b/src/weierstrass/svdw.rs
@@ -66,18 +66,18 @@ impl MapToCurve for SVDW {
     type E = Curve;
     fn map(
         &self,
-        u: <<Self::E as EllipticCurve>::F as Field>::Elt,
+        u: &<<Self::E as EllipticCurve>::F as Field>::Elt,
     ) -> <Self::E as EllipticCurve>::Point {
         let f = self.e.get_field();
         let cmov = FpElt::cmov;
         let sgn0 = Sgn0::new(self.sgn0);
-        let mut t1 = &u ^ 2u32; //          1.   t1 = u^2
+        let mut t1 = u ^ 2u32; //           1.   t1 = u^2
         t1 = t1 * &self.c1; //              2.   t1 = t1 * c1
         let t2 = f.one() + &t1; //          3.   t2 = 1 + t1
         t1 = f.one() - &t1; //              4.   t1 = 1 - t1
         let mut t3 = &t1 * &t2; //          5.   t3 = t1 * t2
         t3 = 1u32 / &t3; //                 6.   t3 = inv0(t3)
-        let mut t4 = &u * &t1; //           7.   t4 = u * t1
+        let mut t4 = u * &t1; //            7.   t4 = u * t1
         t4 = t4 * &t3; //                   8.   t4 = t4 * t3
         t4 = t4 * &self.c3; //              9.   t4 = t4 * c3
         let x1 = &self.c2 - &t4; //         10.  x1 = c2 - t4
@@ -104,7 +104,7 @@ impl MapToCurve for SVDW {
         gx = gx * &x; //                    31.  gx = gx * x
         gx = gx + &self.e.b; //             32.  gx = gx + B
         let mut y = gx.sqrt(); //           33.   y = sqrt(gx)
-        let e3 = sgn0(&u) == sgn0(&y); //   34.  e3 = sgn0(u) == sgn0(y)
+        let e3 = sgn0(u) == sgn0(&y); //    34.  e3 = sgn0(u) == sgn0(y)
         y = cmov(&(-&y), &y, e3); //        35.   y = CMOV(-y, y, e3)
         self.e.new_point(x, y)
     }


### PR DESCRIPTION
This PR include some changes to make it more usable.

The elliptic curve trait can create points from affine coordinates, internally points are projective points.
The FromFactory trait is promoted to ops module, so one can use it for other instances of Factory pattern.


